### PR TITLE
Fixed deprecated import.

### DIFF
--- a/postmark/urls.py
+++ b/postmark/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls.defaults import *
+from django.conf.urls import patterns, url
 
 urlpatterns = patterns("",
     url(r"^bounce/$", "postmark.views.bounce", name="postmark_bounce_hook"),


### PR DESCRIPTION
The deprecated import causes a warning and will be removed in the next stable version of Django (1.6).

See: https://docs.djangoproject.com/en/dev/internals/deprecation/#id3